### PR TITLE
Adding a placeholder image for missing image

### DIFF
--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src="/placeholder.png"
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
Changed the image source to /placeholder.png in frontend.
#4 
![missingitem](https://user-images.githubusercontent.com/96862833/199310107-a90c5f76-ff55-4ba8-bad6-82d19e3dc31d.png)
